### PR TITLE
Higher priority for `symbol` than `pair` in response.

### DIFF
--- a/btfxwss/queue_processor.py
+++ b/btfxwss/queue_processor.py
@@ -147,10 +147,10 @@ class QueueProcessor(Thread):
         channel_name = data.pop('channel')
         channel_id = data.pop('chanId')
         config = data
-        if 'pair' in config:
-            symbol = config['pair']
-        elif 'symbol' in config:
+        if 'symbol' in config:
             symbol = config['symbol']
+        elif 'pair' in config:
+            symbol = config['pair']
         elif 'key' in config:
             symbol = config['key'].split(':')[2][1:]  #layout type:interval:tPair
         else:


### PR DESCRIPTION
According to [the documentation](https://bitfinex.readme.io/v2/docs/ws-general#section-supported-pairs), one should prefix the pairs with a `t` for subscribing to the trading channel, and with an `f` for margin ones.

When the library uses `pair` with a higher priority, it means we can't subscribe to all variants on the same socket. Worse, we need to use `tBTCUSD` for subscribing, `BTCUSD` for accessing through `tickers('BTCUSD')`, and finally it's impossible to unsubscribe due to the mixup. You can try all these with the example in the README. This change fixes all of these problems.